### PR TITLE
Improvements over DataConverter, FragmentsGrouper and Components.

### DIFF
--- a/library/src/components.ts
+++ b/library/src/components.ts
@@ -220,7 +220,8 @@ export class Components {
     Components.update(this.renderer, delta);
     Components.update(this.camera, delta);
     this.tools.update(delta);
-    this._updateRequestCallback = requestAnimationFrame(this.update);
+    const renderer = this.renderer.get();
+    this._updateRequestCallback = renderer.setAnimationLoop(this.update); //Works the same as requestAnimationFrame, but let us use WebXR.
   };
 
   private static update(component: Component<any>, delta: number) {

--- a/library/src/core/simple-renderer.ts
+++ b/library/src/core/simple-renderer.ts
@@ -34,6 +34,7 @@ export class SimpleRenderer
     super();
     this._renderer = new THREE.WebGLRenderer({
       antialias: true,
+      alpha: true
     });
 
     this._renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));

--- a/library/src/fragment/fragment-grouper.ts
+++ b/library/src/fragment/fragment-grouper.ts
@@ -36,15 +36,12 @@ export class FragmentGrouper {
     }
   }
 
-  setVisibility(systemName: string, visible: boolean) {
-    const groupSystem = this.groupSystems[systemName]
-    for (const groupName in groupSystem) {
-      const fragmentsMap = groupSystem[groupName]
-      for (const fragmentId in fragmentsMap) {
-        const fragment = this.fragments.fragments[fragmentId]
-        const ids = fragmentsMap[fragmentId]
-        fragment.setVisibility(ids, visible)
-      }
+  setVisibility(systemName: string, groupName: string, visible: boolean) {
+    const fragmentsMap = this.groupSystems[systemName][groupName]
+    for (const fragmentId in fragmentsMap) {
+      const fragment = this.fragments.fragments[fragmentId]
+      const ids = fragmentsMap[fragmentId]
+      fragment.setVisibility(ids, visible)
     }
   }
 

--- a/library/src/fragment/fragment-grouper.ts
+++ b/library/src/fragment/fragment-grouper.ts
@@ -1,3 +1,5 @@
+import { Fragments } from './fragment';
+
 export interface ItemGroupSystems {
   [systemName: string]: { [groupName: string]: string[] };
 }
@@ -12,6 +14,12 @@ export class FragmentGrouper {
     floor: {},
   };
 
+  fragments: Fragments
+
+  constructor(fragments: Fragments) {
+    this.fragments = fragments
+  }
+
   add(guid: string, groupsSystems: ItemGroupSystems) {
     for (const system in groupsSystems) {
       if (!this.groupSystems[system]) {
@@ -24,6 +32,18 @@ export class FragmentGrouper {
           existingGroups[groupName] = {};
         }
         existingGroups[groupName][guid] = currentGroups[groupName];
+      }
+    }
+  }
+
+  setVisibility(systemName: string, visible: boolean) {
+    const groupSystem = this.groupSystems[systemName]
+    for (const groupName in groupSystem) {
+      const fragmentsMap = groupSystem[groupName]
+      for (const fragmentId in fragmentsMap) {
+        const fragment = this.fragments.fragments[fragmentId]
+        const ids = fragmentsMap[fragmentId]
+        fragment.setVisibility(ids, visible)
       }
     }
   }

--- a/library/src/fragment/fragment-ifc-importer/data-converter.ts
+++ b/library/src/fragment/fragment-ifc-importer/data-converter.ts
@@ -74,7 +74,7 @@ export class DataConverter {
     await this._spatialStructure.setupFloors(webIfc, this._units);
     this.processAllFragmentsData();
     this.processAllUniqueItems();
-    this.saveModelData(webIfc);
+    await this.saveModelData(webIfc);
     return this._model;
   }
 

--- a/library/src/fragment/fragment.ts
+++ b/library/src/fragment/fragment.ts
@@ -28,7 +28,7 @@ export class Fragments extends Component<Fragment[]> {
 
   ifcLoader = new IfcFragmentLoader();
   loader = new FragmentLoader();
-  groups = new FragmentGrouper();
+  groups = new FragmentGrouper(this);
   properties = new FragmentProperties();
   tree = new FragmentSpatialTree(this.properties);
 


### PR DESCRIPTION
1. Awaited on `saveModelData()` under `generateFragmentData()` to have properties available when loading IFC models.
2. Added a handy `setVisibility` function on FragmentGrouper.
3. Changed `requestAnimationFrame` to `setAnimationLoop` to [add support for WebXR].(https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderer.setAnimationLoop).
4. Added alpha to simple-renderer.