### PR TITLE
Little improvements

### DIFF
--- a/library/src/core/simple-camera.ts
+++ b/library/src/core/simple-camera.ts
@@ -1,4 +1,3 @@
-import { Fragments } from './../fragment/fragment';
 import * as THREE from "three";
 import CameraControls from "camera-controls";
 import { Components } from "../components";
@@ -102,11 +101,6 @@ export class SimpleCamera
     controls.dollyToCursor = true;
     controls.infinityDolly = true;
     controls.setTarget(0, 0, 0);
-    const fragments = this.components.tools.get("Fragments") as Fragments
-    if (fragments) { 
-      controls.addEventListener("wake", () => fragments.culler.needsUpdate = true) 
-      controls.addEventListener("rest", () => fragments.culler.needsUpdate = true) 
-    }
     return controls;
   }
 

--- a/library/src/core/simple-camera.ts
+++ b/library/src/core/simple-camera.ts
@@ -1,3 +1,4 @@
+import { Fragments } from './../fragment/fragment';
 import * as THREE from "three";
 import CameraControls from "camera-controls";
 import { Components } from "../components";
@@ -101,6 +102,11 @@ export class SimpleCamera
     controls.dollyToCursor = true;
     controls.infinityDolly = true;
     controls.setTarget(0, 0, 0);
+    const fragments = this.components.tools.get("Fragments") as Fragments
+    if (fragments) { 
+      controls.addEventListener("wake", () => fragments.culler.needsUpdate = true) 
+      controls.addEventListener("rest", () => fragments.culler.needsUpdate = true) 
+    }
     return controls;
   }
 

--- a/library/src/fragment/fragment-grouper.ts
+++ b/library/src/fragment/fragment-grouper.ts
@@ -72,5 +72,21 @@ export class FragmentGrouper {
     return models;
   }
 
+  /**
+   * @description Takes two filters to find the matching groups and return the common fragmentIds and items in them.
+   */
+  intersectGroups(filterA: {[systemName: string]: string}, filterB: {[systemName: string]: string}) {
+      const groupA = this.get(filterA)
+      const groupB = this.get(filterB)
+      const intersection: {[fragmentId: string]: string[]} = {}
+      for (const fragmentId in groupA) {
+          const itemsB = groupB[fragmentId]
+          if (!itemsB) {continue}
+          const itemsA = groupA[fragmentId]
+          intersection[fragmentId] = [...new Set([...itemsA, ...itemsB])]
+      }
+      return intersection
+  }
+
   update(_delta: number): void {}
 }

--- a/library/src/fragment/fragment-ifc-importer/ifc-fragment-loader.ts
+++ b/library/src/fragment/fragment-ifc-importer/ifc-fragment-loader.ts
@@ -58,6 +58,8 @@ export class IfcFragmentLoader {
     await this.loadAllCategories();
     const model = await this._converter.generateFragmentData(this._webIfc);
     this.fragments.models.push(model);
+    const fragmentIds = model.fragments.map( fragment => {return fragment.id} );
+    fragmentIds.forEach( id => this.fragments.fragmentIDModelIDMap[id] = model.uuid );
     this._progress.updateLoadProgress();
     this.cleanUp();
     return model;

--- a/library/src/fragment/fragment-ifc-importer/ifc-fragment-loader.ts
+++ b/library/src/fragment/fragment-ifc-importer/ifc-fragment-loader.ts
@@ -1,3 +1,4 @@
+import { Fragments } from '../fragment';
 import * as WEBIFC from "web-ifc";
 import { IfcToFragmentItems, MaterialList } from "./base-types";
 import { Settings } from "./settings";
@@ -10,6 +11,7 @@ import { DataConverter } from "./data-converter";
  */
 export class IfcFragmentLoader {
   settings = new Settings();
+  fragments: Fragments;
 
   private _webIfc = new WEBIFC.IfcAPI();
   private _progress = new LoadProgress();
@@ -27,6 +29,10 @@ export class IfcFragmentLoader {
     this._materials,
     this.settings
   );
+
+  constructor(fragments: Fragments) {
+    this.fragments = fragments;
+  }
 
   get progress() {
     return this._progress.event;
@@ -51,6 +57,7 @@ export class IfcFragmentLoader {
     await this._progress.setupLoadProgress(this._webIfc);
     await this.loadAllCategories();
     const model = await this._converter.generateFragmentData(this._webIfc);
+    this.fragments.models.push(model);
     this._progress.updateLoadProgress();
     this.cleanUp();
     return model;

--- a/library/src/fragment/fragment.ts
+++ b/library/src/fragment/fragment.ts
@@ -40,6 +40,8 @@ export class Fragments extends Component<Fragment[]> {
   culler: FragmentCulling;
   memoryCuller: MemoryCulling;
 
+  fragmentIDModelIDMap: {[modelID: string]: string} = {};
+
   constructor(private components: Components) {
     super();
     this.highlighter = new FragmentHighlighter(components, this);
@@ -72,7 +74,7 @@ export class Fragments extends Component<Fragment[]> {
     scene.add(fragment.mesh);
   }
 
-  fragmentMapByIds(ids: Array<string>, models: FragmentGroup[] = this.models) {
+  groupIdsByFragment(ids: Array<string>, models = this.models) {
     if (!ids || !models) { return }
     const result: { [fragmentID: string]: string[] } = {}
     models.forEach( model => {

--- a/library/src/fragment/fragment.ts
+++ b/library/src/fragment/fragment.ts
@@ -10,7 +10,7 @@ import { FragmentProperties } from "./fragment-properties";
 import { FragmentSpatialTree } from "./fragment-spatial-tree";
 import { Components } from "../components";
 import { Component } from "../core";
-import { IfcFragmentLoader } from "./fragment-ifc-importer";
+import { FragmentGroup, IfcFragmentLoader } from "./fragment-ifc-importer";
 import { MemoryCulling } from "./memory-culling";
 import { FragmentExploder } from "./fragment-exploder";
 
@@ -25,8 +25,9 @@ export class Fragments extends Component<Fragment[]> {
 
   fragments: { [guid: string]: Fragment } = {};
   fragmentMeshes: THREE.Mesh[] = [];
+  models: FragmentGroup[] = [];
 
-  ifcLoader = new IfcFragmentLoader();
+  ifcLoader = new IfcFragmentLoader(this);
   loader = new FragmentLoader();
   groups = new FragmentGrouper(this);
   properties = new FragmentProperties();
@@ -70,4 +71,17 @@ export class Fragments extends Component<Fragment[]> {
     const scene = this.components.scene.get();
     scene.add(fragment.mesh);
   }
+
+  fragmentMapByIds(ids: Array<string>, models: FragmentGroup[] = this.models) {
+    if (!ids || !models) { return }
+    const result: { [fragmentID: string]: string[] } = {}
+    models.forEach( model => {
+        model.fragments.forEach( fragment => {
+            const found = fragment.items.filter( (item: string) => ids.includes(item) )
+            if (found.length > 0) { result[fragment.id] = found }
+        } )
+    } )
+    return result
+  }
+
 }


### PR DESCRIPTION
- Added `Fragment.models` to store loaded models as `FragmentGroup`. It automatically add a model when using `Fragment.ifcLoader.load`.
- Added `FragmentGrouper.intersectGroups` to return the common fragmentIDs and items in two groups.
- Added `Fragment.groupIdsByFragment` to group all IDs by their corresponding fragments.
- Added `Fragments.fragmentIDModelIDMap`.