### PR TITLE
chore(releases): run publish-npm on any published releases

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,6 +5,11 @@ name: Publish package to npmjs (using Yarn)
 on:
   release:
     types: [published]
+  workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: true
+        type: string
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.16.x' # Use LTS
           registry-url: 'https://registry.npmjs.org'
           scope: '@octocat'
       - run: yarn

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,22 +1,27 @@
 # .github/workflows/release-please.yml
 # This workflow handles the release-please system that manages releasing new versions.
+# It also calls `publish-npm.yml`, which then handles publishing to npmjs.
 # See: https://github.com/googleapis/release-please
+name: release-please
 on:
   push:
     branches:
       - main
-
 permissions:
   contents: write
   pull-requests: write
-
-name: release-please
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v3 # Handle local releases
+        id: release
         with:
           release-type: node
-          package-name: release-please-action
+          package-name: openbim-components
+      - uses: ./.github/workflows/publish-npm.yml # Publish to npmjs
+        with:
+          secrets:
+            NPM_TOKEN: ${{ secrets.NPM_TOKEN }} 
+          # Publish only if release-please creates a published release
+        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
This PR addresses the case where the `publish-npm` workflow doesn't execute after the `release-please` workflow publishes a new release.

It seems that the following snippet

```
on:
  release:
    types: [published]
```

doesn't handle releases published by other workflows, as explained [here](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). This commit corrects this behavior and ensures the workflow runs by directly calling it from the release steps.

The caller workflow also checks that a release has been correctly created before proceeding. In case a manual release is created and published, the `publish-npm` workflow will also perform a release, which could be useful for hot-fixes and patches.