### PR TITLE
fix(project-config): remove labels field from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: "Bug report 🐛"
 description: Report an issue with IFC.js components
-labels: [pending triage]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: "New feature proposal 🚀"
 description: Propose a new feature to be added to IFC.js components
-labels: [pending triage]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This PR removes the "label" field from the issue templates config.