### PR TITLE
Add optional renderer parameters to SimpleRenderer

### DIFF
--- a/src/core/SimpleRenderer/index.ts
+++ b/src/core/SimpleRenderer/index.ts
@@ -34,11 +34,12 @@ export class SimpleRenderer
   protected _renderer2D = new CSS2DRenderer();
   protected _renderer: THREE.WebGLRenderer;
 
-  constructor(public components: Components, public container: HTMLElement) {
+  constructor(public components: Components, public container: HTMLElement, parameters?: Partial<THREE.WebGLRendererParameters>) {
     super();
     this._renderer = new THREE.WebGLRenderer({
       antialias: true,
       alpha: true,
+      ...parameters
     });
 
     this._renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));


### PR DESCRIPTION
Add optional renderer parameters to SimpleRenderer constructor for customised renderer setup.

<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Added an extra optional argument to the constructor of SimpleRenderer to allow for customised initialisation of the internal WebGLRenderer instance. 


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

