### PR TITLE
feat(export): add support for 3d mesh in dxf export

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@popperjs/core": "latest",
-    "@tarikjabiri/dxf": "3.0.0-alpha.2",
+    "@tarikjabiri/dxf": "3.0.0-alpha.4",
     "bim-fragment": "1.0.22",
     "camera-controls": "^1.36.0",
     "dexie": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
   },
   "dependencies": {
     "@popperjs/core": "latest",
+    "@tarikjabiri/dxf": "3.0.0-alpha.2",
     "bim-fragment": "1.0.22",
     "camera-controls": "^1.36.0",
     "dexie": "^3.2.3",
-    "dxf-writer": "^1.18.4",
     "earcut": "^2.2.4",
     "mapbox-gl": "^2.15.0",
     "n8ao": "^1.5.1",

--- a/src/import-export/dxf-exporter/index.html
+++ b/src/import-export/dxf-exporter/index.html
@@ -158,6 +158,16 @@
             link.click();
             link.remove();
         },
+        "Export to 3D DXF": async (plan) => {
+            const link = document.createElement("a");
+            const result = await dxfExporter.export3D();
+            const fileName = `${plan.name}.dxf`;
+            const file = new File([new Blob([result])], fileName);
+            link.href = URL.createObjectURL(file);
+            link.download = fileName;
+            link.click();
+            link.remove();
+        },
     }
 
     await plans.updatePlansList();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,10 +1011,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tarikjabiri/dxf@npm:3.0.0-alpha.2":
-  version: 3.0.0-alpha.2
-  resolution: "@tarikjabiri/dxf@npm:3.0.0-alpha.2"
-  checksum: d0bcf391f9f0dac582212fe9636235220eee943056e5e81109ad27c37cc26a4d1400ff275d765380e1635b95eefe9bfe143fac817b1eb3b05071375c2170b64b
+"@tarikjabiri/dxf@npm:3.0.0-alpha.4":
+  version: 3.0.0-alpha.4
+  resolution: "@tarikjabiri/dxf@npm:3.0.0-alpha.4"
+  checksum: 03d8cc3b7d6744adf6206a20c1f8bb02e0a97483c04d15fdec3112ae921cc6b148ee3cad986780f9a1c540cc7b38943c04a69d51ef3082ee5741b5b294bb6921
   languageName: node
   linkType: hard
 
@@ -6477,7 +6477,7 @@ __metadata:
     "@rollup/plugin-commonjs": 25.0.0
     "@rollup/plugin-node-resolve": 15.1.0
     "@tailwindcss/forms": ^0.5.3
-    "@tarikjabiri/dxf": 3.0.0-alpha.2
+    "@tarikjabiri/dxf": 3.0.0-alpha.4
     "@types/earcut": ^2.1.1
     "@types/jest": 27.0.0
     "@types/mapbox-gl": ^2.7.11

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,6 +1011,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tarikjabiri/dxf@npm:3.0.0-alpha.2":
+  version: 3.0.0-alpha.2
+  resolution: "@tarikjabiri/dxf@npm:3.0.0-alpha.2"
+  checksum: d0bcf391f9f0dac582212fe9636235220eee943056e5e81109ad27c37cc26a4d1400ff275d765380e1635b95eefe9bfe143fac817b1eb3b05071375c2170b64b
+  languageName: node
+  linkType: hard
+
 "@tootallnate/once@npm:1":
   version: 1.1.2
   resolution: "@tootallnate/once@npm:1.1.2"
@@ -6470,6 +6477,7 @@ __metadata:
     "@rollup/plugin-commonjs": 25.0.0
     "@rollup/plugin-node-resolve": 15.1.0
     "@tailwindcss/forms": ^0.5.3
+    "@tarikjabiri/dxf": 3.0.0-alpha.2
     "@types/earcut": ^2.1.1
     "@types/jest": 27.0.0
     "@types/mapbox-gl": ^2.7.11
@@ -6483,7 +6491,6 @@ __metadata:
     canvas: ^2.11.2
     cpy-cli: ^3.1.1
     dexie: ^3.2.3
-    dxf-writer: ^1.18.4
     earcut: ^2.2.4
     eslint: ^7.28.0
     eslint-config-airbnb-base: ^14.2.1


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

A support for 3D mesh in the dxf eport.

I used my new version of my lib [@tarikjabiri/dxf](https://www.npmjs.com/package/@tarikjabiri/dxf/v/3.0.0-alpha.2).

I am currently the maintainer of `dxf-writer`, I cant maintain tow libs, so `dxf-writer` it will be deprecated in future.

My new lib has full support for Typescript. and has more features than the dxf-writer.



### Additional context

Also I will keep your repository up to date with new releases in future, and bug fixes.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
