### PR TITLE
refactor(raycaster): correct variable naming in SimpleRaycaster constructor

### DIFF
--- a/src/core/SimpleRaycaster/index.ts
+++ b/src/core/SimpleRaycaster/index.ts
@@ -19,8 +19,8 @@ export class SimpleRaycaster extends BaseRaycaster implements Disposable {
 
   constructor(components: Components) {
     super(components);
-    const scene = components.renderer.get();
-    const dom = scene.domElement;
+    const renderer = components.renderer.get();
+    const dom = renderer.domElement;
     this.mouse = new Mouse(dom);
   }
 


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

The variable for a get from a raycaster was named scene. This should be raycaster.

### Additional context

nothing was changed except name.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
