### PR TITLE
feat: delete specific measurement

### DIFF
--- a/src/measurement/LengthMeasurement/index.ts
+++ b/src/measurement/LengthMeasurement/index.ts
@@ -227,6 +227,15 @@ export class LengthMeasurement
     }
   }
 
+  async deleteMeasurement(measurement: SimpleDimensionLine) {
+    if (measurement) {
+      const index = this._measurements.indexOf(measurement);
+      this._measurements.splice(index, 1);
+      await measurement.dispose();
+      await this.onAfterDelete.trigger(this);
+    }
+  }
+
   /** Deletes all the dimensions that have been previously created. */
   async deleteAll() {
     for (const dim of this._measurements) {


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->

This interacts with the measurement returned by the onAfterCreate to facilitate external management 
i.e. a react list

Note: I think this should be the default `delete` and the current one should be renamed to `deleteHovered`, but that breaks the API.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
