### PR TITLE
fix: ortho/perspective zoom disparity

### DIFF
--- a/src/navigation/OrthoPerspectiveCamera/index.ts
+++ b/src/navigation/OrthoPerspectiveCamera/index.ts
@@ -131,6 +131,11 @@ export class OrthoPerspectiveCamera extends SimpleCamera implements UI {
     return this._projectionManager.projection;
   }
 
+  /** Match Ortho zoom with Perspective distance when changing projection mode */
+  set matchOrthoDistanceEnabled(value: boolean) {
+    this._projectionManager.matchOrthoDistanceEnabled = value;
+  }
+
   /**
    * Changes the current {@link CameraProjection} from Ortographic to Perspective
    * and Viceversa.


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->
When:
1. Switch to Ortho projection from Perspective
2. Zoom in/out
3. Change back to Perspective

A visual disparity camera disparity is seen, due to the different zoom levels.

This fix translates the ortho zoom back to perspective distance instead of using the saved value.

Note: I think this should be the default behaviour, but don't want to break any code, especially around plans, so it's implemented with a flag 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
