### PR TITLE
fix(components): Fixed OrthoPerspectiveCamera UI bug in OBC 1.1.7

### DIFF
--- a/src/navigation/OrthoPerspectiveCamera/index.ts
+++ b/src/navigation/OrthoPerspectiveCamera/index.ts
@@ -50,9 +50,9 @@ export class OrthoPerspectiveCamera extends SimpleCamera implements UI {
 
     this._projectionManager = new ProjectionManager(components, this);
 
-    if (components.uiEnabled) {
+    components.onInitialized.add(() => {
       this.setUI();
-    }
+    });
 
     this.onAspectUpdated.add(() => this.setOrthoCameraAspect());
   }


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

This PR solves the issue https://github.com/IFCjs/components/issues/172. The reason why it was failing, is because the camera is set before the viewer is initialized, but the UI components need the viewer to be initialized in order for them to be setup. A simple callback when the viewer is initialized did the trick.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
