### PR TITLE
fix(workflow): remove "type" key from publish-npm.yml

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,7 +9,6 @@ on:
     secrets:
       NPM_TOKEN:
         required: true
-        type: string
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,6 +20,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@octocat'
       - run: yarn
-      - run: yarn npm publish
+      - run: yarn publish-repo
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

This PR fixes the following error on the publish-npm GitHub Actions workflow:

```
.github/workflows/publish-npm.yml:12:9: unexpected key "type" for "secrets" section. expected one of "description", "required" [syntax-check]
   |
12 |         type: string
   |         ^~~~~
```

<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
