### PR TITLE
fix(components): 194 - Fixed LengthMeasurement bug while UI Disabled.

### DIFF
--- a/src/ifc/IfcPropertiesProcessor/index.ts
+++ b/src/ifc/IfcPropertiesProcessor/index.ts
@@ -222,13 +222,19 @@ export class IfcPropertiesProcessor
   }
 
   async cleanPropertiesList() {
-    if (this._propertiesManager) {
-      const button = this._propertiesManager.uiElement.get("exportButton");
-      button.removeFromParent();
+    this._currentUI = {};
+    if (this.components.uiEnabled) {
+      if (this._propertiesManager) {
+        const button = this._propertiesManager.uiElement.get("exportButton");
+        button.removeFromParent();
+      }
+      const propsList = this.uiElement.get("propsList");
+      await propsList.dispose(true);
+      const propsWindow =
+        this.uiElement.get<FloatingWindow>("propertiesWindow");
+      propsWindow.description = null;
+      propsList.children = [];
     }
-
-    const propsList = this.uiElement.get("propsList");
-    await propsList.dispose(true);
     // for (const child of this._propsList.children) {
     //   if (child instanceof TreeView) {
     //     this._entityUIPool.return(child);
@@ -236,10 +242,6 @@ export class IfcPropertiesProcessor
     //   }
     //   child.dispose();
     // }
-    const propsWindow = this.uiElement.get<FloatingWindow>("propertiesWindow");
-    propsWindow.description = null;
-    propsList.children = [];
-    this._currentUI = {};
   }
 
   get(): IndexMap {
@@ -273,6 +275,7 @@ export class IfcPropertiesProcessor
   }
 
   async renderProperties(model: FragmentsGroup, expressID: number) {
+    if (!this.components.uiEnabled) return;
     await this.cleanPropertiesList();
     const topToolbar = this.uiElement.get("topToolbar");
     const propsList = this.uiElement.get("propsList");

--- a/src/navigation/OrthoPerspectiveCamera/index.ts
+++ b/src/navigation/OrthoPerspectiveCamera/index.ts
@@ -52,7 +52,7 @@ export class OrthoPerspectiveCamera extends SimpleCamera implements UI {
     this._projectionManager = new ProjectionManager(components, this);
 
     components.onInitialized.add(() => {
-      this.setUI();
+      if (components.uiEnabled) this.setUI();
     });
 
     this.onAspectUpdated.add(() => this.setOrthoCameraAspect());

--- a/src/utils/VertexPicker/index.ts
+++ b/src/utils/VertexPicker/index.ts
@@ -161,11 +161,12 @@ export class VertexPicker
   }
 
   private setupEvents(active: boolean) {
-    const container = this._components.ui.viewerContainer;
+    const container = this.components.renderer.get().domElement.parentElement;
+    if (!container) return;
     if (active) {
       container.addEventListener("mousemove", this.update);
     } else {
-      container.addEventListener("mousemove", this.update);
+      container.removeEventListener("mousemove", this.update);
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

This PR solves issue https://github.com/IFCjs/components/issues/194. The problem was the VertexPicker was taking the viewer container from the UI Manager, but the UI Manager never gets initialized if the developer decides to disable the built-in UI by using `components.uiEnabled = false`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
