### PR TITLE
fix: publish npm package on successful release-please execution

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,13 +13,18 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: google-github-actions/release-please-action@v3 # Handle local releases
         id: release
         with:
           release-type: node
           package-name: openbim-components
-      - uses: ./.github/workflows/publish-npm.yml # Publish to npmjs
-        with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: ${{ steps.release.outputs.release_created }}
+  publish-npm:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ./.github/workflows/publish-npm.yml # Publish to npmjs
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }} 
+    # Publish only if release-please creates a published release


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description
This PR fixes the release-please workflow PR, which currently fails at the npm package publish step. It now is in the same state as the [fragment](https://github.com/IFCjs/fragment) release-please workflow.

<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
