### PR TITLE
feat: allow bounding box to use simple meshes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbim-components",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "main": "src/index.js",
   "author": "harry collin, antonio gonzalez viegas",
   "license": "MIT",

--- a/src/fragments/FragmentBoundingBox/index.ts
+++ b/src/fragments/FragmentBoundingBox/index.ts
@@ -1,6 +1,5 @@
 import * as THREE from "three";
 import { FragmentsGroup } from "bim-fragment";
-import { InstancedMesh } from "three";
 import { Component, Disposable, Event } from "../../base-types";
 import { Components, Disposer, ToolComponent } from "../../core";
 
@@ -117,7 +116,7 @@ export class FragmentBoundingBox extends Component<void> implements Disposable {
     }
   }
 
-  addMesh(mesh: InstancedMesh) {
+  addMesh(mesh: THREE.InstancedMesh | THREE.Mesh) {
     if (!mesh.geometry.index) {
       return;
     }
@@ -128,14 +127,20 @@ export class FragmentBoundingBox extends Component<void> implements Disposable {
     const meshTransform = mesh.matrix;
 
     const instanceTransform = new THREE.Matrix4();
-    for (let i = 0; i < mesh.count; i++) {
-      mesh.getMatrixAt(i, instanceTransform);
+    const isInstanced = mesh instanceof THREE.InstancedMesh;
+    const count = isInstanced ? mesh.count : 1;
+
+    for (let i = 0; i < count; i++) {
       const min = bbox.min.clone();
       const max = bbox.max.clone();
 
-      min.applyMatrix4(instanceTransform);
+      if (isInstanced) {
+        mesh.getMatrixAt(i, instanceTransform);
+        min.applyMatrix4(instanceTransform);
+        max.applyMatrix4(instanceTransform);
+      }
+
       min.applyMatrix4(meshTransform);
-      max.applyMatrix4(instanceTransform);
       max.applyMatrix4(meshTransform);
 
       if (min.x < this._absoluteMin.x) this._absoluteMin.x = min.x;
@@ -156,7 +161,7 @@ export class FragmentBoundingBox extends Component<void> implements Disposable {
     }
   }
 
-  private static getFragmentBounds(mesh: InstancedMesh) {
+  private static getFragmentBounds(mesh: THREE.InstancedMesh | THREE.Mesh) {
     const position = mesh.geometry.attributes.position;
 
     const maxNum = Number.MAX_VALUE;


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

The previous bounding box only allows to use Instanced Meshes. This PR extends it so that it also admits regular meshes.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
