### PR TITLE
feat(components): Implemented setup on ScreenCuller

### DIFF
--- a/src/core/ScreenCuller/index.html
+++ b/src/core/ScreenCuller/index.html
@@ -94,6 +94,7 @@
 	 */
 
 	const culler = new OBC.ScreenCuller(components);
+  await culler.setup()
 
 	/*MD
 

--- a/src/core/ScreenCuller/index.ts
+++ b/src/core/ScreenCuller/index.ts
@@ -7,6 +7,7 @@ import { readPixelsAsync } from "./src/screen-culler-helper";
 import { Disposer } from "../Disposer";
 import { ToolComponent } from "../ToolsComponent";
 import { FragmentManager } from "../../fragments/FragmentManager";
+import { FragmentHighlighter } from "../../fragments/FragmentHighlighter";
 
 // TODO: Work at the instance level instead of the mesh level?
 
@@ -300,8 +301,16 @@ export class ScreenCuller
         this._currentVisibleMeshes.add(mesh.uuid);
         this._recentlyHiddenMeshes.delete(mesh.uuid);
         if (mesh instanceof FragmentMesh) {
+          const highlighter = this.components.tools.get(FragmentHighlighter);
+          const { cullHighlightMeshes, selectName } = highlighter.config;
+          if (!cullHighlightMeshes) {
+            continue;
+          }
           const fragments = mesh.fragment.fragments;
           for (const name in fragments) {
+            if (name === selectName) {
+              continue;
+            }
             const fragment = fragments[name];
             fragment.mesh.visible = true;
           }
@@ -315,8 +324,16 @@ export class ScreenCuller
       if (mesh === undefined) continue;
       mesh.visible = false;
       if (mesh instanceof FragmentMesh) {
+        const highlighter = this.components.tools.get(FragmentHighlighter);
+        const { cullHighlightMeshes, selectName } = highlighter.config;
+        if (!cullHighlightMeshes) {
+          continue;
+        }
         const fragments = mesh.fragment.fragments;
         for (const name in fragments) {
+          if (name === selectName) {
+            continue;
+          }
           const fragment = fragments[name];
           fragment.mesh.visible = false;
         }

--- a/src/fragments/FragmentBoundingBox/index.ts
+++ b/src/fragments/FragmentBoundingBox/index.ts
@@ -2,7 +2,9 @@ import * as THREE from "three";
 import { FragmentsGroup } from "bim-fragment";
 import { InstancedMesh } from "three";
 import { Component, Disposable, Event } from "../../base-types";
-import { Components, Disposer, ToolComponent } from "../../core";
+import { Components } from "../../core/Components";
+import { Disposer } from "../../core/Disposer";
+import { ToolComponent } from "../../core/ToolsComponent";
 
 /**
  * A simple implementation of bounding box that works for fragments. The resulting bbox is not 100% precise, but

--- a/src/fragments/FragmentHighlighter/index.ts
+++ b/src/fragments/FragmentHighlighter/index.ts
@@ -35,6 +35,7 @@ export interface FragmentHighlighterConfig {
   selectionMaterial: THREE.Material;
   hoverMaterial: THREE.Material;
   autoHighlightOnClick: boolean;
+  cullHighlightMeshes: boolean;
 }
 
 export class FragmentHighlighter
@@ -101,6 +102,7 @@ export class FragmentHighlighter
       depthTest: true,
     }),
     autoHighlightOnClick: true,
+    cullHighlightMeshes: true,
   };
 
   private _mouseState = {

--- a/src/fragments/FragmentHighlighter/index.ts
+++ b/src/fragments/FragmentHighlighter/index.ts
@@ -1,21 +1,18 @@
 import * as THREE from "three";
 import { Fragment, FragmentMesh } from "bim-fragment";
 import {
-  Component,
   Disposable,
   Updateable,
   Event,
   FragmentIdMap,
   Configurable,
 } from "../../base-types";
+import { Component } from "../../base-types/component";
 import { FragmentManager } from "../FragmentManager";
 import { FragmentBoundingBox } from "../FragmentBoundingBox";
-import {
-  Components,
-  ScreenCuller,
-  SimpleCamera,
-  ToolComponent,
-} from "../../core";
+import { Components } from "../../core/Components";
+import { SimpleCamera } from "../../core/SimpleCamera";
+import { ToolComponent } from "../../core/ToolsComponent";
 import { toCompositeID } from "../../utils";
 import { PostproductionRenderer } from "../../navigation/PostproductionRenderer";
 
@@ -38,7 +35,6 @@ export interface FragmentHighlighterConfig {
   selectionMaterial: THREE.Material;
   hoverMaterial: THREE.Material;
   autoHighlightOnClick: boolean;
-  cullHighlightMesh: boolean;
 }
 
 export class FragmentHighlighter
@@ -105,7 +101,6 @@ export class FragmentHighlighter
       depthTest: true,
     }),
     autoHighlightOnClick: true,
-    cullHighlightMesh: true,
   };
 
   private _mouseState = {
@@ -476,15 +471,7 @@ export class FragmentHighlighter
       if (!fragment.fragments[name]) {
         const material = this.highlightMats[name];
         const subFragment = fragment.addFragment(name, material);
-        if (this.config.cullHighlightMesh) {
-          const culler = this.components.tools.get(ScreenCuller);
-          if (
-            name !== this.config.selectName &&
-            name !== this.config.hoverName
-          ) {
-            culler.add(subFragment.mesh);
-          }
-        }
+        subFragment.group = fragment.group;
         if (fragment.blocks.count > 1) {
           subFragment.setInstance(0, {
             ids: Array.from(fragment.ids),


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description
This PR does two things:

1. Implement the [configurable interface](https://docs.thatopen.com/api/interfaces/openbim_components.Configurable) in the ScreenCuller.
2. Fixes a culling problem on highlight meshes.
3. Updated the ScreenCuller example.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
