### PR TITLE
fix: Optional categories reset after initial loading in FragmentIfcLoader

### DIFF
--- a/src/fragments/FragmentIfcLoader/index.ts
+++ b/src/fragments/FragmentIfcLoader/index.ts
@@ -133,8 +133,8 @@ export class FragmentIfcLoader
     await this.readIfcFile(data);
 
     await this.readAllGeometries();
-    await this._geometry.streamAlignment(this._webIfc);
-    await this._geometry.streamCrossSection(this._webIfc);
+    this._geometry.streamAlignment(this._webIfc);
+    this._geometry.streamCrossSection(this._webIfc);
 
     const items = this._geometry.items;
     const civItems = this._geometry.CivilItems;
@@ -221,7 +221,7 @@ export class FragmentIfcLoader
     this._converter.saveIfcCategories(this._webIfc);
 
     // Some categories (like IfcSpace) need to be created explicitly
-    const optionals = this.settings.optionalCategories;
+    const optionals = [...this.settings.optionalCategories];
 
     // Force IFC space to be transparent
     if (optionals.includes(WEBIFC.IFCSPACE)) {


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description
This PR solves issue https://github.com/IFCjs/components/issues/251.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
