### PR TITLE
fix: FragmentTree must not be a tool

### DIFF
--- a/src/fragments/FragmentTree/index.ts
+++ b/src/fragments/FragmentTree/index.ts
@@ -7,7 +7,7 @@ import {
   UIElement,
 } from "../../base-types";
 import { FragmentTreeItem } from "./src/tree-item";
-import { Components, ToolComponent } from "../../core";
+import { Components } from "../../core";
 import { FragmentClassifier } from "../FragmentClassifier";
 import { Button, FloatingWindow } from "../../ui";
 
@@ -15,10 +15,8 @@ export class FragmentTree
   extends Component<FragmentTreeItem>
   implements UI, Disposable
 {
-  static readonly uuid = "5af6ebe1-26fc-4053-936a-801b6c7cb37e" as const;
-
   /** {@link Disposable.onDisposed} */
-  readonly onDisposed = new Event<string>();
+  readonly onDisposed = new Event<undefined>();
 
   enabled: boolean = true;
   onSelected = new Event<{ items: FragmentIdMap; visible: boolean }>();
@@ -31,8 +29,6 @@ export class FragmentTree
 
   constructor(components: Components) {
     super(components);
-
-    this.components.tools.add(FragmentTree.uuid, this);
   }
 
   get(): FragmentTreeItem {
@@ -63,7 +59,7 @@ export class FragmentTree
     if (this._tree) {
       await this._tree.dispose();
     }
-    await this.onDisposed.trigger(FragmentTree.uuid);
+    await this.onDisposed.trigger();
     this.onDisposed.reset();
   }
 
@@ -136,5 +132,3 @@ export class FragmentTree
     return groups;
   }
 }
-
-ToolComponent.libraryUUIDs.add(FragmentTree.uuid);


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description
This PR remove the FragmentTree to be a tool. It mustn't be one because then developers can't create multiple trees.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
