### PR TITLE
fix yarn build error

### DIFF
--- a/packages/front/src/fragments/Highlighter/index.ts
+++ b/packages/front/src/fragments/Highlighter/index.ts
@@ -46,8 +46,7 @@ export interface HighlighterConfig {
  */
 export class Highlighter
   extends OBC.Component
-  implements OBC.Disposable, OBC.Eventable
-{
+  implements OBC.Disposable, OBC.Eventable {
   /**
    * A unique identifier for the component.
    * This UUID is used to register the component within the Components system.
@@ -267,8 +266,10 @@ export class Highlighter
     const caster = casters.get(world);
     const result = caster.castRay(allMeshes);
 
-    if ((!result || !result.face) && removePrevious) {
-      this.clear(name);
+    if (!result || !result.face) {
+      if (removePrevious) {
+        this.clear(name);
+      }
       return null;
     }
 


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Running yarn build (and yarn build-libraries in particular) produces the following errors:

```
PS C:\p\engine_components> yarn build
README.md successfully copied to packages/core/
README.md successfully copied to packages/front/
vite v5.1.6 building for production...
✓ 237 modules transformed.

[vite:dts] Start generate declaration files...
dist/index.mjs  1,081.29 kB │ gzip: 227.40 kB
Generating namespace!
[vite:dts] Declaration files built in 3118ms.

dist/index.cjs  1,089.58 kB │ gzip: 228.00 kB
dist/index.min.mjs  531.30 kB │ gzip: 152.11 kB
dist/index.min.cjs  533.70 kB │ gzip: 152.13 kB
✓ built in 9.20s
src/fragments/Highlighter/index.ts:275:18 - error TS18047: 'result' is possibly 'null'.

275     const mesh = result.object as FragmentMesh;
                     ~~~~~~

src/fragments/Highlighter/index.ts:279:11 - error TS18047: 'result' is possibly 'null'.

279       if (result.faceIndex === undefined || !mesh.geometry.index) {
              ~~~~~~

src/fragments/Highlighter/index.ts:285:47 - error TS18047: 'result' is possibly 'null'.

285       const itemFoundInFillMesh = fragMap.get(result.faceIndex!);
                                                  ~~~~~~

src/fragments/Highlighter/index.ts:307:24 - error TS18047: 'result' is possibly 'null'.

307     const instanceID = result.instanceId;
                           ~~~~~~


Found 4 errors in the same file, starting at: src/fragments/Highlighter/index.ts:275
```
(Windows 11, yarn 3.2.1)

This PR fixes the error.

One other line was altered by applying formatting.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
