### PR TITLE
fix: Vulnerability in fast-xml-parser <5.3.4

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "camera-controls": "^2.9.0",
-    "fast-xml-parser": "4.4.1",
+    "fast-xml-parser": "5.3.4",
     "jszip": "3.10.1",
     "three-mesh-bvh": "0.7.0"
   },


### PR DESCRIPTION
### Description

fast-xml-parser has a  "high" vulnerability between version 4.3.6 and 5.3.3 with 5.3.4 being the fix

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
