### PR TITLE
fix(Highlighter): auto toggle single item

### DIFF
--- a/packages/front/src/fragments/Highlighter/index.ts
+++ b/packages/front/src/fragments/Highlighter/index.ts
@@ -282,10 +282,6 @@ export class Highlighter
 
     this.events[name].onBeforeHighlight.trigger(this.selection[name]);
 
-    if (removePrevious) {
-      await this.clear(name);
-    }
-
     let map = OBC.ModelIdMapUtils.clone(modelIdMap);
     const fragments = this.components.get(OBC.FragmentsManager);
 
@@ -314,8 +310,16 @@ export class Highlighter
       OBC.ModelIdMapUtils.remove(map, exclude);
     }
 
+    const autoTogglePicking = isPicking && this.autoToggle.has(name);
+    const toggleFullSelection = autoTogglePicking && OBC.ModelIdMapUtils.isEqual(this.selection[name], map);
+
+    // If the full selection is toggled on click (like a single item clicked twice), clear must be prevented to let the auto toggle picking logic handle this special use case
+    if (removePrevious && !toggleFullSelection) {
+      await this.clear(name);
+    }
+
     // Apply autotoggle when picking with the mouse
-    if (isPicking && this.autoToggle.has(name)) {
+    if (autoTogglePicking) {
       const clearedItems: { [key: string]: Set<number> } = {};
       let clearedItemsFound = false;
 


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

The current [Highlighter](https://github.com/ThatOpen/engine_components/blob/main/packages/front/src/fragments/Highlighter/index.ts) cannot auto toggle a single item. This is because the previous selection [is cleared](https://github.com/ThatOpen/engine_components/blob/main/packages/front/src/fragments/Highlighter/index.ts#L285-L287) before the [auto toggle picking logic](https://github.com/ThatOpen/engine_components/blob/main/packages/front/src/fragments/Highlighter/index.ts#L318) is done.

**Steps to reproduce:**
- setup the Highlighter with autoToggle on (or test on [the official Highlighter example](https://docs.thatopen.com/Tutorials/Components/Front/Highlighter#-highlighting-items))
- select an item
- select the same item twice
-> Nothing change, the item is still highlighted

**Workaround:** pressing the [`multiple` key](https://github.com/ThatOpen/engine_components/blob/main/packages/front/src/fragments/Highlighter/index.ts#L43) (ctrl on the example) let the item be deselected. This is because the [`multiple`](https://github.com/ThatOpen/engine_components/blob/main/packages/front/src/fragments/Highlighter/index.ts#L43) config [is then interpreted](https://github.com/ThatOpen/engine_components/blob/main/packages/front/src/fragments/Highlighter/index.ts#L661-L662) as not `removePrevious`, [preventing the clear to be done](https://github.com/ThatOpen/engine_components/blob/main/packages/front/src/fragments/Highlighter/index.ts#L285-L287).

**Solution:**
If picking and auto toggle are `true`, prevent clearing the selection if the new requested selection is the same as the current one. Letting the code take the same path as if `multiple` is pressed, deselecting the item 🎉 .

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
