### PR TITLE
fix(deps): address CVE-2026-26278 in fast-xml-parser

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "web-ifc": "0.0.74"
   },
   "dependencies": {
-    "fast-xml-parser": "5.3.7",
+    "fast-xml-parser": "5.5.6",
     "jszip": "3.10.1",
     "three-mesh-bvh": "0.7.0"
   },


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->
The initial fix (#704) was merged previously, but we received an alert that it was incomplete.

Description:
The previous fix added entity expansion limits (maxTotalExpansions, maxExpandedLength, maxEntityCount, maxEntitySize) to prevent XML entity expansion Denial of Service. However, these limits are only enforced for DOCTYPE-defined entities. Numeric character references (&#NNN; and &#xHH;) and standard XML entities (&lt;, &gt;, etc.) are processed through a separate code path that does NOT enforce any expansion limits.

An attacker can use massive numbers of numeric entity references to completely bypass all configured limits, causing excessive memory allocation and CPU consumption.

This new version fixes the issue.
https://security.snyk.io/package/npm/fast-xml-parser/versions?page=1

Note: I did not include the package-lock changes. Please install the new package versions and update the package lock separately.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
