### PR TITLE
fix(Highlighter): fix highlighter clear not working correctly with filter

### DIFF
--- a/packages/front/src/fragments/Highlighter/index.ts
+++ b/packages/front/src/fragments/Highlighter/index.ts
@@ -494,7 +494,7 @@ export class Highlighter
       }
 
       // Clean up selection map for this style
-      this.selection[style] = {};
+      OBC.ModelIdMapUtils.remove(this.selection[style], clearedItems);
     }
 
     if (!this._fromHighlight) {


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

The `Highlighter.clear` has a bug because of which the `filter` parameter is not applied. The issue is with the `Highlighter.selection[highlightName]` getting reset which causes the full selection to be cleared even though the consumer may only want to clear the passed `filter`.

This PR fixes that issue by removing only the items to be cleared from `Highlighter.selection[highlightName]` and not fully resetting it.

### Additional context

N/A

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
