### PR TITLE
fix(viewpoint): Fix Viewpoint camera capture to use real world camera pose

### DIFF
--- a/packages/core/src/core/Viewpoints/src/viewpoint.ts
+++ b/packages/core/src/core/Viewpoints/src/viewpoint.ts
@@ -447,14 +447,9 @@ export class Viewpoint {
         throw new Error("Viewpoint: world's camera need camera controls!");
       }
 
-      const position = new THREE.Vector3();
-      camera.controls.getPosition(position);
-
       const threeCamera = camera.three;
-
-      const direction = new THREE.Vector3(0, 0, -1).applyEuler(
-        threeCamera.rotation,
-      );
+      const position = threeCamera.getWorldPosition(new THREE.Vector3());
+      const direction = threeCamera.getWorldDirection(new THREE.Vector3());
 
       const { width, height } = renderer.getSize();
       let aspect_ratio = width / height;


### PR DESCRIPTION
### Summary

This change improves Viewpoint fidelity by capturing the actual rendered camera pose (world position + world forward direction) instead of deriving it from controls state and local rotation.

### Problem and how to reproduce

Viewpoints created after orbit-point operations could replay to a slightly different location/orientation than where they were captured.

- Move the camera
- Set [camera orbit point](https://github.com/yomotsu/camera-controls/blob/dev/src/CameraControls.ts#L2341)
- Create a viewpoint
- Replaying it
->> The location is not the same as when the viewpoint was created.

**Why I may set orbit point ? **


https://github.com/user-attachments/assets/97e5aba3-a268-41a4-a132-f66153073bb7

My viewer uses custom orbit point to rotate the model at the pointer coordinates.

### Root Cause

In [viewpoint.ts](https://github.com/ThatOpen/engine_components/blob/main/packages/core/src/core/Viewpoints/src/viewpoint.ts), Viewpoint capture previously used:
- controls position from camera-controls
- direction computed from local Euler rotation

That is fragile when camera uses focal offset (for example after setOrbitPoint).

### What Changed

In [viewpoint.ts](https://github.com/ThatOpen/engine_components/blob/main/packages/core/src/core/Viewpoints/src/viewpoint.ts) :

Capture position with `threeCamera.getWorldPosition(...)`
Capture direction with `threeCamera.getWorldDirection(...)`

No public API changes. Only capture logic in Viewpoint.updateCamera was updated.

### Why This Is Better
- Captures exactly what the user sees in the viewport.
- Makes create and later go replay much more consistent.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
