### PR TITLE
docs(CONTRIBUTING): build cmd in setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,7 @@ packages/
 git clone https://github.com/ThatOpen/engine_components.git
 cd engine_components
 yarn install
+yarn build-core && yarn build-front
 yarn dev
 ```
 


### PR DESCRIPTION
I am trying to setup engine_components locally by following the CONTRIBUTING guide.
```bash
yarn install
yarn dev
```

These commands are insufficient setup.
I get the following error:

```bash
✘ [ERROR] Failed to resolve entry for package "@thatopen/components". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-scan]

    node_modules/esbuild/lib/main.js:1374:21:
      1374 │         let result = await callback({
```

I see that the packages are not built.
Building resolves this issue.