### PR TITLE
fix(outline-pass): handle clipping planes

### DIFF
--- a/packages/front/src/core/PostproductionRenderer/src/simple-outline-pass.ts
+++ b/packages/front/src/core/PostproductionRenderer/src/simple-outline-pass.ts
@@ -46,14 +46,21 @@ interface OutlinedTileProxy {
 }
 
 const GHOST_VERT = `
+  #include <clipping_planes_pars_vertex>
   void main() {
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+    gl_Position = projectionMatrix * mvPosition;
+    #include <clipping_planes_vertex>
   }
 `;
 
 const GHOST_FRAG = `
+  #include <clipping_planes_pars_fragment>
   uniform vec4 idColor;
-  void main() { gl_FragColor = idColor; }
+  void main() {
+    #include <clipping_planes_fragment>
+    gl_FragColor = idColor;
+  }
 `;
 
 /**
@@ -268,6 +275,7 @@ export class SimpleOutlinePass extends Pass {
       polygonOffsetFactor: -priority,
       polygonOffsetUnits: -priority,
     });
+    material.clipping = true;
 
     const container = new THREE.Group();
     container.name = `outline-group:${name}`;

--- a/packages/front/src/core/PostproductionRenderer/src/simple-outline-pass.ts
+++ b/packages/front/src/core/PostproductionRenderer/src/simple-outline-pass.ts
@@ -266,6 +266,7 @@ export class SimpleOutlinePass extends Pass {
 
     const material = new THREE.ShaderMaterial({
       uniforms: { idColor: { value: new THREE.Vector4(id / 255, 0, 0, 1) } },
+      clipping: true,
       vertexShader: GHOST_VERT,
       fragmentShader: GHOST_FRAG,
       depthTest: true,
@@ -275,7 +276,6 @@ export class SimpleOutlinePass extends Pass {
       polygonOffsetFactor: -priority,
       polygonOffsetUnits: -priority,
     });
-    material.clipping = true;
 
     const container = new THREE.Group();
     container.name = `outline-group:${name}`;


### PR DESCRIPTION
### Description

Outlined items are not cut by scene clipping planes.

**Before:**

<img width="564" height="671" alt="Screenshot 2026-07-02 at 15 59 37" src="https://github.com/user-attachments/assets/f5870870-2337-4e01-b333-d066e34255fb" />

**After:**

<img width="600" height="679" alt="Screenshot 2026-07-02 at 16 00 53" src="https://github.com/user-attachments/assets/885173a0-c6f5-46ac-8984-76b46d69ef1e" />

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Additional context

[Done the same way in edge detection pass.](https://github.com/ThatOpen/engine_components/blob/main/packages/front/src/core/PostproductionRenderer/src/edge-detection-pass.ts#L104-L134)

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
