### PR TITLE
fix(): dynamicAnchor memory leak

### DIFF
--- a/packages/core/src/core/Worlds/src/simple-world.ts
+++ b/packages/core/src/core/Worlds/src/simple-world.ts
@@ -73,6 +73,7 @@ export class SimpleWorld<
     } else {
       container.removeEventListener("pointerdown", this.onPointerDown);
     }
+    this._dynamicAnchor = value;
   }
 
   get dynamicAnchor() {
@@ -233,6 +234,13 @@ export class SimpleWorld<
   dispose(disposeResources = true) {
     this.enabled = false;
     this.isDisposing = true;
+
+    // Remove the dynamic anchoring listener before the renderer is disposed
+    const container = this.renderer?.three.domElement.parentElement;
+    if (container) {
+      container.removeEventListener("pointerdown", this.onPointerDown);
+    }
+    this._dynamicAnchor = false;
 
     this.scene.onWorldChanged.trigger({ world: this, action: "removed" });
     this.camera.onWorldChanged.trigger({ world: this, action: "removed" });


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Using `dynamicAnchor` introduces memory leak (surfaces in react) - It never cleans up on dispose

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
