### PR TITLE
fix(camera): deep zooming velocity with `dynamicAnchor`

### DIFF
--- a/packages/core/src/core/Worlds/src/simple-camera.ts
+++ b/packages/core/src/core/Worlds/src/simple-camera.ts
@@ -9,6 +9,36 @@ import {
 } from "../../../fragments";
 
 /**
+ * Move the orbit point to an anchored surface without letting the camera
+ * jump or the zoom decay.
+ *
+ * `CameraControls.setOrbitPoint` internally calls `dollyTo(distance)`, which
+ * clamps the orbit radius to `[minDistance, maxDistance]`. If the anchored
+ * surface sits closer than `minDistance`, that clamp would snap the camera
+ * backwards, so the anchor has to be placed with a near-zero `minDistance`.
+ *
+ * But `minDistance` is also what stops the zoom from decaying: with
+ * `dollyToCursor` + `infinityDolly` the wheel step is proportional to the
+ * orbit radius, and the constant-speed "infinity" push only kicks in once the
+ * radius reaches `minDistance`. Leaving `minDistance` near zero (as dynamic
+ * anchoring used to, globally) let the radius shrink toward zero on every
+ * zoom-in, so each notch moved exponentially less — the zoom felt like it was
+ * grinding to a halt until a press re-anchored it. So we drop `minDistance`
+ * only for the placement itself and restore it immediately, keeping the real
+ * `minDistance` in force for the wheel.
+ */
+export function setOrbitPoint(controls: CameraControls, point: THREE.Vector3) {
+  const { minDistance } = controls;
+  controls.minDistance = 0.01;
+  controls.setOrbitPoint(
+    point.x,
+    point.y,
+    point.z,
+  );
+  controls.minDistance = minDistance;
+}
+
+/**
  * A basic camera that uses [yomotsu's cameracontrols](https://github.com/yomotsu/camera-controls) to control the camera in 2D and 3D. Check out it's API to find out what features it offers.
  */
 export class SimpleCamera extends BaseCamera implements Updateable, Disposable {
@@ -150,11 +180,7 @@ export class SimpleCamera extends BaseCamera implements Updateable, Disposable {
 
   async setOrbitToItems(items?: ModelIdMap) {
     const sphere = await this.getItemsBounding(items);
-    this.controls.setOrbitPoint(
-      sphere.center.x,
-      sphere.center.y,
-      sphere.center.z,
-    );
+    setOrbitPoint(this.controls, sphere.center);
   }
 
   /** {@link Updateable.update} */

--- a/packages/core/src/core/Worlds/src/simple-world.ts
+++ b/packages/core/src/core/Worlds/src/simple-world.ts
@@ -11,7 +11,7 @@ import {
   Updateable,
 } from "../../Types";
 import { Disposer } from "../../Disposer";
-import { Worlds } from "..";
+import { setOrbitPoint, Worlds } from "..";
 import { Raycasters } from "../../Raycasters";
 
 /**
@@ -70,7 +70,6 @@ export class SimpleWorld<
       );
     }
     if (value) {
-      if (this.camera.controls) this.camera.controls.minDistance = 0.01;
       container.addEventListener("pointerdown", this.onPointerDown);
     } else {
       container.removeEventListener("pointerdown", this.onPointerDown);
@@ -120,11 +119,7 @@ export class SimpleWorld<
     // snapping around as the pointer crosses gaps between objects.
     const planePoint = this.getPlaneAnchor(caster, position);
     if (planePoint) {
-      this.camera.controls.setOrbitPoint(
-        planePoint.x,
-        planePoint.y,
-        planePoint.z,
-      );
+      setOrbitPoint(this.camera.controls, planePoint);
     }
 
     // Then refine to the real geometry depth once the (asynchronous) pick
@@ -136,8 +131,7 @@ export class SimpleWorld<
       const isStale = requestId !== this._anchorRequestId;
       if (isStale || this.isDisposing || !this._dynamicAnchor) return;
       if (!result?.point || !this.camera.hasCameraControls()) return;
-      const { x, y, z } = result.point;
-      this.camera.controls.setOrbitPoint(x, y, z);
+      setOrbitPoint(this.camera.controls, result.point);
     });
   };
 


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Zooming is expected to be an exponential operand derived by the wheel event.
Currently, when setting `dynamicAnchor  = true` zooming decays very quickly until it barely moves.
Rotating the camera restores some zoom ability.
This PR fixes the root cause (camera controls `minDistance` set by `dynamicAnchor` logic).
I wonder if setting `minDistance` is really needed. Kept it for safety. If not let's remove it.
This fix is partial - it restores the ability to zoom in depth, but it does not fix zooming to the expected behavior. That is a different fix and is unrelated/invariant to `dynamicAnchor`.
related #770

### Before


https://github.com/user-attachments/assets/ff95a5c7-db6c-4807-b16a-b3c2df1d8cff





### After

https://github.com/user-attachments/assets/db938d62-cdab-4c7c-bfc7-f3ae2cfdb17f


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
