### PR TITLE
fix(postproduction): keep MSAA when postproduction is enabled

### DIFF
--- a/packages/front/src/core/PostproductionRenderer/example.ts
+++ b/packages/front/src/core/PostproductionRenderer/example.ts
@@ -266,6 +266,15 @@ const panel = BUI.Component.create<BUI.PanelSection>(() => {
         }}">
       </bim-checkbox>
 
+      <bim-number-input
+        slider step="1" label="MSAA samples"
+        value="${world.renderer!.postproduction.samples}" min="0" max="8"
+        @change="${({ target }: { target: BUI.NumberInput }) => {
+          world.renderer!.postproduction.samples = target.value;
+          updateIfManualMode();
+        }}">
+      </bim-number-input>
+
       <bim-dropdown required label="Postproduction style"
         @change="${({ target }: { target: BUI.Dropdown }) => {
           const result = target.value[0] as OBF.PostproductionAspect;

--- a/packages/front/src/core/PostproductionRenderer/src/index.ts
+++ b/packages/front/src/core/PostproductionRenderer/src/index.ts
@@ -48,6 +48,7 @@ export class Postproduction {
   private _glossEnabled = false;
   private _smaaEnabled = false;
   private _excludedObjectsEnabled = false;
+  private _samples = 4;
   private _components: OBC.Components;
   private _renderer: PostproductionRenderer;
   private _clearColor = new THREE.Color();
@@ -154,6 +155,16 @@ export class Postproduction {
   set smaaEnabled(value: boolean) {
     this._smaaEnabled = value;
     this.style = this._style;
+  }
+
+  /** MSAA sample count of the composer render targets; 0 renders them without multisampling. */
+  get samples() {
+    return this._samples;
+  }
+
+  set samples(value: number) {
+    this._samples = value;
+    this.applySamples();
   }
 
   get style() {
@@ -370,6 +381,19 @@ export class Postproduction {
     this._renderer.three.setRenderTarget(null);
   }
 
+  private applySamples() {
+    if (!this.composer) return;
+    const max = this._renderer.three.capabilities.maxSamples;
+    const samples = Math.max(0, Math.min(Math.floor(this._samples), max));
+    const targets = [this.composer.renderTarget1, this.composer.renderTarget2];
+    for (const target of targets) {
+      if (target.samples === samples) continue;
+      target.samples = samples;
+      // the framebuffer is re-created with the new sample count on next use
+      target.dispose();
+    }
+  }
+
   private initialize() {
     this._initialized = true;
 
@@ -380,6 +404,9 @@ export class Postproduction {
     this._renderer.three.setClearColor(0x000000, 0);
 
     this.composer = new EffectComposer(this._renderer.three);
+    // EffectComposer allocates its ping-pong targets with samples = 0, which
+    // would drop the MSAA of the default framebuffer as soon as postproduction is on
+    this.applySamples();
 
     const basePass = new BasePass(scene, camera);
     this._basePass = basePass;


### PR DESCRIPTION
### Description

Fixes #793.

`Postproduction.initialize()` creates the `EffectComposer` without a render target, so three.js allocates the ping-pong targets with `samples = 0`. The moment postproduction is enabled, the hardware MSAA of the default framebuffer is gone and every geometry edge is aliased; SMAA only partly recovers it, which is why the postproduction image looks "noisier" than the plain render.

This PR gives the composer targets a sample count:

- new `Postproduction.samples` (default `4`, clamped to `renderer.capabilities.maxSamples`; `0` restores the previous behaviour), applied right after the composer is created and re-applied by the setter (`samples` change + `dispose()`, so the framebuffer is re-created on next use);
- `setSize()` needs no change — `WebGLRenderTarget.setSize()` keeps `samples`;
- the PostproductionRenderer example gets an "MSAA samples" slider next to the SMAA checkbox.

Measured on an office-building model, fixed exterior view, Chrome / AMD Radeon 8060S, 1665×1123 ("hard edges" = share of neighbouring pixel pairs whose luma differs by more than 60):

| | hard edges | render ms |
|---|---|---|
| postproduction on, `samples = 0` (before) | 43.5 % | 12.2 |
| postproduction on, `samples = 4` (this PR) | **33.7 %** | 12.8 |
| postproduction off (default framebuffer, MSAA) | 36.2 % | 9.9 |
| postproduction on, `samples = 0`, pixel ratio 2 | 33.6 % | 13.2 |

i.e. the same edge quality as pixel ratio 2 for ~0.6 ms per frame instead of 4× the fill rate.

### Additional context

- The composer targets carry no `depthTexture`; the AO / edge-detection passes keep their own single-sample targets, so nothing else changes.
- `yarn build-libraries` currently fails on `main` in `packages/core` against the published `@thatopen/fragments@3.4.7` (`FragmentsModels.getWorker`, `getLocalIdsFromItemIds` are not released yet) — unrelated to this change; `tsc` for `packages/front` reports no errors in `PostproductionRenderer`, and the front Vite build succeeds.
- The pre-existing eslint/prettier findings in the two touched files (import order, `fragPaths` line, extraneous-deps in the example) are left as they are to keep the diff minimal.

---

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (`fixes #793`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it. (No test harness in this repo; the example exposes the setting.)
